### PR TITLE
Bugfix/docker compose mysql bug

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,7 @@ services:
       - ./docker/create_databases.sql:/docker-entrypoint-initdb.d/create_databases.sql
     healthcheck:
       test:
-        ["CMD", "/bin/sh", "-c", "mysql -u root -e USE 'civilservant_development;' && echo 'ok'"]
+        ["CMD", "/bin/sh", "-c", "mysql -u root -e 'USE civilservant_development;' && echo 'ok'"]
       start_period: 5s
       interval: 5s
       retries: 10


### PR DESCRIPTION
Fixing bug in compose.yml healthcheck for MYSQL container where semicolon was included in database name