### PR TITLE
adding test_send_intervention_message

### DIFF
--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -512,6 +512,8 @@ class BanneduserExperimentController(ModactionExperimentController):
                         )
                         self.db_session.add(ea)
                         experiment_thing.metadata_json = metadata_json
+            # NOTE: experiment_things also become updated in database with this commit method,
+            # as they are sqlalchemy objects
             self.db_session.commit()
         except Exception as e:
             self.log.error(

--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -59,7 +59,9 @@ class BanneduserExperimentController(ModactionExperimentController):
         This is a callback that will be invoked declaratively. This is called by ModeratorController while running archive_mod_action_page, as noted in the experiment config YAML File.
         """
         if instance.fetched_subreddit_id != self.experiment_settings["subreddit_id"]:
-            self.log.error(f"subreddit mismatch. fetched: {instance.fetched_subreddit_id}, experiment: {self.experiment_settings['subreddit_id']}")
+            self.log.error(
+                f"subreddit mismatch. fetched: {instance.fetched_subreddit_id}, experiment: {self.experiment_settings['subreddit_id']}"
+            )
             return
 
         self.log.info(
@@ -267,7 +269,7 @@ class BanneduserExperimentController(ModactionExperimentController):
             if len(newcomer_ets) > 0:
                 self.db_session.insert_retryable(ExperimentThing, newcomer_ets)
                 self.experiment.settings_json = json.dumps(self.experiment_settings)
-                
+
             self.log.info(
                 f"Assigned randomizations to {len(newcomer_ets)} banned users: [{','.join([x['thing_id'] for x in newcomer_ets])}]"
             )
@@ -456,7 +458,7 @@ class BanneduserExperimentController(ModactionExperimentController):
             # send messages_to_send
             message_results = mc.send_messages(
                 messages_to_send,
-                f"BannedUserMessagingExperiment({self.experiment_name})::_send_intervention_messages"
+                f"BannedUserMessagingExperiment({self.experiment_name})::_send_intervention_messages",
             )
 
             # iterate through message_result, linked with experiment_things

--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -409,19 +409,20 @@ class BanneduserExperimentController(ModactionExperimentController):
         return {"subject": message_subject, "message": message_body}
 
     def _send_intervention_messages(self, experiment_things):
-        """Format intervention message for an experiment thing, given the arm that it is in.
-        This reads from the experiment_settings (the YAML file in /config/experiments/).
+        """Sends appropriate intervention messages for a list of experiment things.
 
         Args:
             experiment_things: A list of ExperimentThings representing tempbanned users.
 
         Returns:
-            A dict with message subject and body.
+            A dict with server response from praw's send_message,
+            or a dict with key 'error' if there was an error sending a message.
 
         Example result:
             {
-                "subject": "Tempban Message",
-                "message": "You have been temporarily banned...",
+                "LaLaLatour47": {
+                    ....
+                }
             }
         """
         self.db_session.execute(

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -500,6 +500,41 @@ class TestPrivateMethods:
         with pytest.raises(ExperimentConfigurationError):
             experiment_controller._format_intervention_message(et)
 
-    @pytest.mark.skip
-    def test_send_intervention_messages(self):
-        pass
+    @pytest.mark.parametrize(
+        "thing_id,metadata_json",
+        [
+            (
+                "ThusSpoke44",
+                {
+                    "condition": "newcomer",
+                    "arm": "arm_1",
+                },
+            ),
+            (
+                "LaLaLatour47",
+                {
+                    "condition": "experienced",
+                    "arm": "arm_2",
+                },
+            ),
+        ],
+    )
+    def test_send_intervention_messages(
+        self, thing_id, metadata_json, db_session, experiment_controller
+    ):
+
+        et = ExperimentThing(
+            id=thing_id,
+            thing_id=thing_id,
+            experiment_id=experiment_controller.experiment.id,
+            object_type=ThingType.USER.value,
+            metadata_json=json.dumps(metadata_json),
+        )
+        experiment_controller._send_intervention_messages([et])
+
+        assert (
+            experiment_controller.db_session.query(ExperimentAction)
+            .filter(ExperimentAction.action_object_id == thing_id)
+            .count()
+            == 1
+        )


### PR DESCRIPTION
Test checks for the proper logging of an ExperimentAction in the db.

Addressing Issue #54.

Question @wllrd:
1. This test assumes that the testing of send_message itself is handled by `test_messaging_controller.py` Errors in input would be handled by `test_format_intervention_message`. I think like I'm missing an error case - thoughts on what I could be testing for that would be specific to the _sending_ of the message?

