### PR TITLE
Exclude very new users from the study

### DIFF
--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -96,11 +96,9 @@ class BanneduserExperimentController(ModactionExperimentController):
         """Filter a list of mod actions to find newcomers to the experiment.
         Starting with a list of arbitrary mod actions, select mod actions that:
         - are not for users already in the study,
-        - are temporary bans, and
-        - do not appear to be bots.
-
-        NOTE: We also exclude very new accounts.
-        That happens in `_assign_randomized_conditions` because it requires extra user data.
+        - are temporary bans,
+        - do not appear to be bots, and
+        - have existed for more than one week.
 
         Args:
             modactions: A list of mod actions.

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -293,7 +293,7 @@ class TestPrivateMethods:
 
         assert len(experiment_controller._previously_enrolled_user_ids()) > 1
 
-    def test_assign_randomized_conditions_exclusion(
+    def test_assign_randomized_conditions__new_accounts_exclusion(
         self, modaction_data, experiment_controller
     ):
         user_modactions = experiment_controller._find_eligible_newcomers(modaction_data)

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -253,7 +253,7 @@ class TestPrivateMethods:
     )
     def test_get_account_age_bucket(self, seconds_ago, want, experiment_controller):
         now = datetime.datetime.utcnow().timestamp()
-        age = experiment_controller._get_account_age_bucket(now - seconds_ago)
+        age = experiment_controller._get_account_age_bucket(now, now - seconds_ago)
         assert age == want
 
     @pytest.mark.parametrize(
@@ -266,7 +266,7 @@ class TestPrivateMethods:
     def test_get_condition(self, seconds_ago, want, experiment_controller):
         # NOTE: Condition is currently the same value as `_get_account_age_bucket`.
         now = datetime.datetime.utcnow().timestamp()
-        condition = experiment_controller._get_condition(now - seconds_ago)
+        condition = experiment_controller._get_condition(now, now - seconds_ago)
         assert condition == want
 
     @pytest.mark.parametrize(
@@ -279,12 +279,13 @@ class TestPrivateMethods:
     def test_is_too_new(self, seconds_ago, want, experiment_controller):
         # NOTE: Condition is currently the same value as `_get_account_age_bucket`.
         now = datetime.datetime.utcnow().timestamp()
-        condition = experiment_controller._is_too_new(now - seconds_ago)
+        condition = experiment_controller._is_too_new(now, now - seconds_ago)
         assert condition == want
 
     def test_assign_randomized_conditions(self, modaction_data, experiment_controller):
+        now = datetime.datetime.utcnow().timestamp()
         user_modactions = experiment_controller._find_eligible_newcomers(modaction_data)
-        experiment_controller._assign_randomized_conditions(user_modactions)
+        experiment_controller._assign_randomized_conditions(now, user_modactions)
         assert len(experiment_controller._previously_enrolled_user_ids()) > 1
 
     @pytest.mark.parametrize(

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -67,8 +67,13 @@ def mod_controller(db_session, mock_reddit, logger, experiment_controller):
 
 
 @pytest.fixture
-def newcomer_modactions(experiment_controller, modaction_data):
-    return experiment_controller._find_eligible_newcomers(modaction_data)
+def static_now():
+    return datetime.datetime.utcnow().timestamp()
+
+
+@pytest.fixture
+def newcomer_modactions(static_now, experiment_controller, modaction_data):
+    return experiment_controller._find_eligible_newcomers(static_now, modaction_data)
 
 
 class TestRedditMock:
@@ -182,10 +187,20 @@ class TestPrivateMethods:
         experiment_controller.db_session.commit()
         assert experiment_controller._previously_enrolled_user_ids() == want
 
-    def test_find_eligible_newcomers(self, modaction_data, experiment_controller):
+    def test_find_eligible_newcomers(self, modaction_data, experiment_controller, static_now):
         # NOTE: not using newcomer_modactions for extra clarity.
-        user_modactions = experiment_controller._find_eligible_newcomers(modaction_data)
+        user_modactions = experiment_controller._find_eligible_newcomers(static_now, modaction_data)
         assert len(user_modactions) > 0
+
+    def test_find_eligible_newcomers__new_accounts_exclusion(
+        self, modaction_data, experiment_controller
+    ):
+        # NOTE: currently, all mock redditors have a creation timestamp 9999.
+        now = 10001
+        user_modactions = experiment_controller._find_eligible_newcomers(now, modaction_data)
+
+        assert len(user_modactions) == 0
+
 
     # update temp ban duration
     @pytest.mark.parametrize(
@@ -217,7 +232,7 @@ class TestPrivateMethods:
         helpers.load_mod_actions(mod_controller, experiment_controller)
         experiment_controller.enroll_new_participants(mod_controller)
 
-        original = newcomer_modactions[0]
+        original = newcomer_modactions[0][0]
         update = {**original, "action": action, "details": details}
         experiment_controller._update_existing_participants([update])
 
@@ -253,9 +268,8 @@ class TestPrivateMethods:
             (864001, "experienced"),
         ],
     )
-    def test_get_account_age_bucket(self, seconds_ago, want, experiment_controller):
-        now = datetime.datetime.utcnow().timestamp()
-        age = experiment_controller._get_account_age_bucket(now, now - seconds_ago)
+    def test_get_account_age_bucket(self, seconds_ago, want, experiment_controller, static_now):
+        age = experiment_controller._get_account_age_bucket(static_now, static_now - seconds_ago)
         assert age == want
 
     @pytest.mark.parametrize(
@@ -265,10 +279,9 @@ class TestPrivateMethods:
             (864001, "experienced"),
         ],
     )
-    def test_get_condition(self, seconds_ago, want, experiment_controller):
+    def test_get_condition(self, seconds_ago, want, experiment_controller, static_now):
         # NOTE: Condition is currently the same value as `_get_account_age_bucket`.
-        now = datetime.datetime.utcnow().timestamp()
-        condition = experiment_controller._get_condition(now, now - seconds_ago)
+        condition = experiment_controller._get_condition(static_now, static_now - seconds_ago)
         assert condition == want
 
     @pytest.mark.parametrize(
@@ -278,30 +291,17 @@ class TestPrivateMethods:
             (864001, False),
         ],
     )
-    def test_is_too_new(self, seconds_ago, want, experiment_controller):
-        # NOTE: Condition is currently the same value as `_get_account_age_bucket`.
-        now = datetime.datetime.utcnow().timestamp()
-        condition = experiment_controller._is_too_new(now, now - seconds_ago)
+    def test_is_too_new(self, seconds_ago, want, experiment_controller, static_now):
+        condition = experiment_controller._is_too_new(static_now, static_now - seconds_ago)
         assert condition == want
 
-    def test_assign_randomized_conditions(self, modaction_data, experiment_controller):
+    def test_assign_randomized_conditions(self, modaction_data, experiment_controller, static_now):
         assert len(experiment_controller._previously_enrolled_user_ids()) == 0
 
-        now = datetime.datetime.utcnow().timestamp()
-        user_modactions = experiment_controller._find_eligible_newcomers(modaction_data)
-        experiment_controller._assign_randomized_conditions(now, user_modactions)
+        user_modactions = experiment_controller._find_eligible_newcomers(static_now, modaction_data)
+        experiment_controller._assign_randomized_conditions(static_now, user_modactions)
 
         assert len(experiment_controller._previously_enrolled_user_ids()) > 1
-
-    def test_assign_randomized_conditions__new_accounts_exclusion(
-        self, modaction_data, experiment_controller
-    ):
-        user_modactions = experiment_controller._find_eligible_newcomers(modaction_data)
-        # NOTE: currently, all mock redditors have a creation timestamp 9999.
-        now = 10001
-        experiment_controller._assign_randomized_conditions(now, user_modactions)
-
-        assert len(experiment_controller._previously_enrolled_user_ids()) == 0
 
     @pytest.mark.parametrize(
         "action,details,want",

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -251,9 +251,9 @@ class TestPrivateMethods:
             (864001, "experienced"),
         ],
     )
-    def test_get_account_age(self, seconds_ago, want, experiment_controller):
+    def test_get_account_age_bucket(self, seconds_ago, want, experiment_controller):
         now = datetime.datetime.utcnow().timestamp()
-        age = experiment_controller._get_account_age(now - seconds_ago)
+        age = experiment_controller._get_account_age_bucket(now - seconds_ago)
         assert age == want
 
     @pytest.mark.parametrize(
@@ -264,9 +264,22 @@ class TestPrivateMethods:
         ],
     )
     def test_get_condition(self, seconds_ago, want, experiment_controller):
-        # NOTE: Condition is currently the same value as `_get_account_age`.`
+        # NOTE: Condition is currently the same value as `_get_account_age_bucket`.
         now = datetime.datetime.utcnow().timestamp()
         condition = experiment_controller._get_condition(now - seconds_ago)
+        assert condition == want
+
+    @pytest.mark.parametrize(
+        "seconds_ago,want",
+        [
+            (1, True),
+            (864001, False),
+        ],
+    )
+    def test_is_too_new(self, seconds_ago, want, experiment_controller):
+        # NOTE: Condition is currently the same value as `_get_account_age_bucket`.
+        now = datetime.datetime.utcnow().timestamp()
+        condition = experiment_controller._is_too_new(now - seconds_ago)
         assert condition == want
 
     def test_assign_randomized_conditions(self, modaction_data, experiment_controller):
@@ -481,7 +494,6 @@ class TestPrivateMethods:
         want_user_message_status,
         experiment_controller,
     ):
-
         assert experiment_controller.db_session.query(ExperimentAction).count() == 0
         assert experiment_controller.db_session.query(ExperimentThing).count() == 0
 

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -72,6 +72,8 @@ def newcomer_modactions(experiment_controller, modaction_data):
 
 
 class TestRedditMock:
+    """NOTE: The reddit mock is part of a higher level test structure, beyond the banned user experiment."""
+
     def test_fake_mod_log_first_page(self, mock_reddit):
         page = mock_reddit.get_mod_log("fake_subreddit")
         assert len(page) == 100
@@ -283,10 +285,23 @@ class TestPrivateMethods:
         assert condition == want
 
     def test_assign_randomized_conditions(self, modaction_data, experiment_controller):
+        assert len(experiment_controller._previously_enrolled_user_ids()) == 0
+
         now = datetime.datetime.utcnow().timestamp()
         user_modactions = experiment_controller._find_eligible_newcomers(modaction_data)
         experiment_controller._assign_randomized_conditions(now, user_modactions)
+
         assert len(experiment_controller._previously_enrolled_user_ids()) > 1
+
+    def test_assign_randomized_conditions_exclusion(
+        self, modaction_data, experiment_controller
+    ):
+        user_modactions = experiment_controller._find_eligible_newcomers(modaction_data)
+        # NOTE: currently, all mock redditors have a creation timestamp 9999.
+        now = 10001
+        experiment_controller._assign_randomized_conditions(now, user_modactions)
+
+        assert len(experiment_controller._previously_enrolled_user_ids()) == 0
 
     @pytest.mark.parametrize(
         "action,details,want",


### PR DESCRIPTION
Update the experiment to exclude new users, i.e. those whose accounts were created within the past 7 days. Previously, this condition had been tested as the `newcomer` category; that category should now never apply because such users are excluded from the study altogether.

One thing to keep in mind is that while it would be ideal to do the filtering in `_find_eligible_newcomers`, we actually do it in `_assign_randomized_conditions` because we need the results of the API call to Reddit to get the account age.

As requested in #66 

## Test plan

Tests pass, in particular `test_assign_randomized_conditions_exclusion`