### PR TITLE
Edits to enable running system test with banneduser_experiment_controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ target/
 #VSCode
 .vscode
 CivilServant.code-workspace
+
+venv/

--- a/config/experiments/banneduser_experiment_test.yml
+++ b/config/experiments/banneduser_experiment_test.yml
@@ -1,7 +1,7 @@
-test:
-  subreddit: CivilServantBot2
+production:
+  subreddit: catlabreddit_testbu1
   subreddit_id: mouw
-  username: CivilServantBot
+  username: catlabreddit
   conditions:
     newcomer:
       randomizations: banneduser_experiment_test.newcomer.randomizations.test.csv

--- a/schedule_experiments.py
+++ b/schedule_experiments.py
@@ -18,7 +18,7 @@ def main():
                         help="The experiment")
 
     parser.add_argument("job",
-                         choices=["sticky_comment_intervene", "tidy", "archive_submissions", "send_newcomer_messages"],
+                         choices=["sticky_comment_intervene", "tidy", "archive_submissions", "send_newcomer_messages", "conduct_banuser_experiment"],
                          help="The job associated with the experiment")
 
     parser.add_argument("interval",
@@ -88,6 +88,16 @@ def main():
         scheduler.schedule(
                 scheduled_time=datetime.utcnow(),
                 func=app.controller.update_newcomer_messaging_experiment,
+                args=[args.experiment],
+                kwargs={'_profile': args.profile},
+                interval=int(args.interval),
+                repeat=None,
+                timeout = timeout_seconds,
+                result_ttl = ttl)
+    elif(args.job == "conduct_banuser_experiment"):
+        scheduler.schedule(
+                scheduled_time=datetime.utcnow(),
+                func=app.controller.conduct_banuser_experiment,
                 args=[args.experiment],
                 kwargs={'_profile': args.profile},
                 interval=int(args.interval),

--- a/supervisord.conf.example
+++ b/supervisord.conf.example
@@ -1,0 +1,24 @@
+[supervisord]
+user=root
+environment=CS_ENV="production",PYTHONPATH=.,AIRBRAKE_API_KEY=<API_KEY_HERE>,AIRBRAKE_PROJECT_ID=<ID>,AIRBRAKE_ENVIRONMENT=<ENV>,AIRBRAKE_BASE_URL=<URL>
+
+[group:all]
+programs=rqscheduler,rqworker,rq-dashboard,praw-multiprocess
+
+[program:rqscheduler]
+directory=/cs/civilservant
+command=/cs/civilservant/venv/bin/rqscheduler
+
+[program:rqworker]
+directory=/cs/civilservant
+command=/cs/civilservant/venv/bin/rqworker production 
+
+[program:rq-dashboard]
+directory=/cs/civilservant
+command=/cs/civilservant/venv/bin/rq-dashboard
+
+[program:praw-multiprocess]
+directory=/cs/civilservant
+command=/cs/civilservant/venv/bin/praw-multiprocess
+
+


### PR DESCRIPTION
- Adding conducting banuser experiment functionality to `app/controller.py`, `schedule_experiment.py`
- Fixing yaml_load error in `app/controller.py` 
- Editing config yaml files for dryrun server test - `banneduser_experiment_test.yaml`
- Adding `supervisord.conf.example` file that starts `rqscheduler`, `rqworker`, `rq-dashboard`, `praw-multiprocess`
- Adding `venv/` to `.gitignore`

