### PR TITLE
Fix failing tests with mod action filter

### DIFF
--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -209,7 +209,7 @@ class BanneduserExperimentController(ModactionExperimentController):
                 if user.query_index == BannedUserQueryIndex.PENDING:
                     user.query_index = BannedUserQueryIndex.IMPOSSIBLE
 
-            user_metadata['last_applied_modaction'] = modaction.created_utc
+            user_metadata['last_applied_modaction'] = int(modaction.created_utc)
             user.metadata_json = json.dumps(user_metadata)
 
             self.db_session.add(user)

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -69,7 +69,7 @@ def mod_controller(db_session, mock_reddit, logger, experiment_controller):
 
 @pytest.fixture
 def static_now():
-    return datetime.datetime.utcnow().timestamp()
+    return int(datetime.datetime.utcnow().timestamp())
 
 
 @pytest.fixture

--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -227,7 +227,7 @@ class TestPrivateMethods:
         experiment_controller.enroll_new_participants(mod_controller)
 
         original = newcomer_modactions[0]
-        update = DictObject({**original, "action": action, "details": details})
+        update = DictObject({**original, "action": action, "details": details, "created_utc": original.created_utc + 1})
         experiment_controller._update_existing_participants(static_now, [update])
 
         snap = (


### PR DESCRIPTION
This fixes a few minor regressions in tests:

- Cast timestamp to int in more places
- Increment timestamp for "update" test -- faux-new modactions were being discarded because we started filtering out mod actions with timestamps that look like they'd already been applied!