### PR TITLE
Process mod actions from the database rather than the API

### DIFF
--- a/app/controllers/modaction_experiment_controller.py
+++ b/app/controllers/modaction_experiment_controller.py
@@ -1,9 +1,14 @@
 import abc
+from contextlib import contextmanager
+import datetime
+import json
 
 from sqlalchemy import and_
 
 from app.controllers.experiment_controller import ExperimentController
-from app.models import ExperimentThing, ExperimentThingSnapshot, ThingType
+from app.models import ExperimentThing, ModAction, ThingType
+
+MOD_ACTION_CURSOR_KEY = "last_modaction_timestamp"
 
 
 class ModactionExperimentController(ExperimentController, abc.ABC):
@@ -29,6 +34,63 @@ class ModactionExperimentController(ExperimentController, abc.ABC):
     @abc.abstractmethod
     def _get_condition(self):
         """Get the condition name to use in this experiment."""
+
+    @contextmanager
+    def _new_modactions(self, should_save_cursor=True):
+        """Load new mod actions.
+
+        They should be recorded:
+        - after the end of the experiment,
+        - after the last processed mod action, if any, and
+        - before the end of the experiment.
+
+        The query has a few notable properties:
+        - Use an exclusive range to avoid confusion related to processing the same time more than once.
+        - Limit result size. Repeated runs will advance through large batches of mod actions.
+
+        Args:
+            should_save_cursor: whether to save the `last_modaction_timestamp` cursor in experiment settings
+
+        Yields:
+            A list of new mod actions for the experiment.
+        """
+        first_time = self.experiment.start_time + datetime.timedelta(seconds=1)
+        window_start = max(first_time, self._last_modaction_time())
+        window_end = self.experiment.end_time + datetime.timedelta(seconds=1)
+        modactions = (
+            self.db_session.query(ModAction)
+            .filter(
+                and_(
+                    ModAction.created_utc > window_start,
+                    ModAction.created_utc < window_end,
+                )
+            )
+            .order_by(ModAction.created_utc.asc())
+            .limit(500)
+            .all()
+        )
+
+        # XXX: parse `action_data` and set *ephemeral* values on the model instance.
+        for m in modactions:
+            meta = json.loads(m.action_data).get("json_dict", {})
+            for k, v in meta.items():
+                if not hasattr(m, k):
+                    setattr(m, k, v)
+
+        yield modactions
+        if len(modactions) > 0 and should_save_cursor:
+            # NOTE: modactions are sorted by created_utc, so the last one is always the max timestamp.
+            last_modaction = modactions[-1]
+            self.experiment_settings[MOD_ACTION_CURSOR_KEY] = int(
+                last_modaction.created_utc.timestamp()
+            )
+            self.experiment.settings_json = json.dumps(self.experiment_settings)
+            self.db_session.add_retryable(self.experiment)
+
+    def _last_modaction_time(self):
+        return datetime.datetime.fromtimestamp(
+            self.experiment_settings.get(MOD_ACTION_CURSOR_KEY, 0)
+        )
 
     def _check_condition(self, name):
         """Check whether the named condition is configured for this experiment.

--- a/config/experiments/banneduser_experiment_test.yml
+++ b/config/experiments/banneduser_experiment_test.yml
@@ -44,8 +44,8 @@ production:
           pm_subject: PM Subject Line for {username} (Thirtydays Arm 1)
           pm_text: Hello {username}, this is the message for arm 1 of the thirtydays condition.
   controller: BanneduserExperimentController
-  start_time: 07/02/2024 00:00:00 UTC
-  end_time: 07/02/3024 23:59:59 UTC
+  start_time: 07/02/2000 00:00:00 UTC
+  end_time: 07/02/3000 23:59:59 UTC
   event_hooks:
     test_after_comments:
       is_active: True
@@ -57,7 +57,7 @@ production:
       callee_method: enroll_new_participants
 test:
   subreddit: catlabreddit_testbu1
-  subreddit_id: mouw
+  subreddit_id: TEST_ONLY
   username: catlabreddit
   conditions:
     threedays:
@@ -101,8 +101,8 @@ test:
           pm_subject: PM Subject Line for {username} (Thirtydays Arm 1)
           pm_text: Hello {username}, this is the message for arm 1 of the thirtydays condition.
   controller: BanneduserExperimentController
-  start_time: 07/02/2024 00:00:00 UTC
-  end_time: 07/02/3024 23:59:59 UTC
+  start_time: 07/02/2000 00:00:00 UTC
+  end_time: 07/02/3000 23:59:59 UTC
   event_hooks:
     test_after_comments:
       is_active: True


### PR DESCRIPTION
This makes a significant change to the way mod actions are processed in the banned user experiment, and undermines some of the underlying CivilServant framework. 😈 Key changes are:

* Query mod actions from the database, ignoring the API results that are passed through immediately after fetching.
* Query in batches, meaning that the code should run somewhat frequently and is likely to be more efficient and have predictable perf characteristics.
* Store a cursor to the last mod action timestamp on the `experiments` table inside the serialized JSON settings. (Note that a timestamp isn't ideal and it would be better to use a counter, but this should be good enough for our purposes.)
* Only ever consider mod actions that happened *during* the experiment.
* Add a context manager to load mod actions, and use it to persist the cursor position for the experiment.
* Remove per-record cursors and associated logic.
* Update mod action test fixture loader to set all subreddit IDs to a standard value, in order to prevent unexpected skips. This prevents some unexpected (to me) skipping of test data.
* Add tests for the new databasey stuff.
* Remove dead test code around Redditor API lookups

## Feedback needed / possible loose ends

* Will mod actions appear in queries right after they're saved, or will they only surface on the next run? (e.g. because of a table lock)
* Do we need to add a read lock on the `mod_actions` table? (Probably.)
* Generally, where should full-table locking be applied?
* Is the experiment cursor being saved properly?
* ~~Is this happening inside a transaction? (If not, it should be!)~~ (yes)

## Test plan

* Old tests pass, with minor changes. Note they are not all testing with database results!
* New tests (for fetching and cursor) also pass.
* Will need to do a staging test run and inspect database results.