### PR TITLE
Production bugfixes

### DIFF
--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -57,7 +57,7 @@ class BanneduserExperimentController(ModactionExperimentController):
         self, experiment_name, db_session, r, log, required_keys=["event_hooks"]
     ):
         super().__init__(experiment_name, db_session, r, log, required_keys)
-        self.log_prefix = '{0} Experiment {1}:'.format(self.__class__.__name__, experiment_name)
+        self.log_prefix = f'{self.__class__.__name__} Experiment {experiment_name}:'
 
     def enroll_new_participants(
         self, instance, now_utc=int(datetime.utcnow().timestamp())

--- a/app/cs_logger.py
+++ b/app/cs_logger.py
@@ -1,5 +1,8 @@
 import airbrake
-from concurrent_log_handler import ConcurrentRotatingFileHandler
+try:
+    from concurrent_log_handler import ConcurrentRotatingFileHandler
+except ImportError:
+    from cloghandler import ConcurrentRotatingFileHandler
 import os, sys, random, logging
 from time import sleep
 import pathlib


### PR DESCRIPTION
- `cs_logger.py` import works across both `concurrent_log_handler` and `cloghandler` module names
- `banneduser_experiment_controller::enroll_new_participants` triggers an info log message instead of an error when a modactions job for a different subreddit triggers it
- Updating logs with a prefix to be consistent with previous CivilServant experiment log format
