### PR TITLE
Remove read locks from ban experiment

### DIFF
--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -76,7 +76,7 @@ class BanneduserExperimentController(ModactionExperimentController):
             return
 
         self.db_session.execute(
-            "LOCK TABLES comments READ, experiments WRITE, experiment_things WRITE, experiment_thing_snapshots WRITE, mod_actions READ"
+            "LOCK TABLES experiments WRITE, experiment_things WRITE, experiment_thing_snapshots WRITE"
         )
         try:
             with self._new_modactions() as modactions:


### PR DESCRIPTION
Lighten up the concurrency pressure of this experiment by not locking tables it doesn't change.