### PR TITLE
Revert "Remove read locks from ban experiment"

### DIFF
--- a/app/controllers/banneduser_experiment_controller.py
+++ b/app/controllers/banneduser_experiment_controller.py
@@ -76,7 +76,7 @@ class BanneduserExperimentController(ModactionExperimentController):
             return
 
         self.db_session.execute(
-            "LOCK TABLES experiments WRITE, experiment_things WRITE, experiment_thing_snapshots WRITE"
+            "LOCK TABLES comments READ, experiments WRITE, experiment_things WRITE, experiment_thing_snapshots WRITE, mod_actions READ"
         )
         try:
             with self._new_modactions() as modactions:


### PR DESCRIPTION
```
Arguments: ('Error in BanneduserExperimentController::enroll_new_participants', OperationalError('(MySQLdb._exceptions.OperationalError) (1100, "Table \'mod_actions\' was not locked with LOCK TABLES")',))
```

🤦 

Reverts citizensandtech/CivilServant#114