### PR TITLE
Ignore unbanusers that happen immediately after a banuser action

### DIFF
--- a/tests/test_banneduser_experiment_controller.py
+++ b/tests/test_banneduser_experiment_controller.py
@@ -365,6 +365,20 @@ class TestPrivateMethods:
         assert got == want
 
     @pytest.mark.parametrize(
+        "action,want",
+        [
+            ("unbanuser", True),
+            ("banuser", False),
+            ("removecomment", False),
+        ],
+    )
+    def test_is_unban(self, action, want, experiment_controller):
+        got = experiment_controller._is_unban(
+            DictObject({"action": action})
+        )
+        assert got == want
+
+    @pytest.mark.parametrize(
         "action,details,want",
         [
             ("banuser", "3 days", False),


### PR DESCRIPTION
Addressing #118.

One question is - how do we test this? I did a temporary test by altering the `mod_actions_banusers.json` to add a `unbanuser` modlog event and it worked. Would a proper test involve 1) adding a bit of fixture data and hard-coding a test to match specific fixture data? 2) Inserting fixture modlog data into the test itself? 3) Something else?